### PR TITLE
Add Relient to community products list

### DIFF
--- a/data/products.ts
+++ b/data/products.ts
@@ -98,4 +98,11 @@ export const products = [
     href: "https://todaylist.carrd.co/",
     logo: "https://todaylist.carrd.co/assets/images/image04.jpg?v20902614940451",
   },
+  {
+    title: "Relient",
+    description: "Client portal for agencies to share tasks, leads, timelines, and receive payments.",
+    href: "https://relient.in",
+    logo: "https://relient.in/relient.png"
+  }
+  
 ];

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -14,6 +14,7 @@ const nextConfig = {
 			{ hostname: 'github.com' },
 			{ hostname: 'ui.metamorix.com' },
 			{ hostname: 'todaylist.carrd.co' },
+			{ hostname: 'relient.in' }
 		],
 	},
 };


### PR DESCRIPTION
This PR adds Relient —  to the Indie Hackers Army product list. It helps agencies share tasks, leads, timelines, and receive payments, all in one place.